### PR TITLE
Replace full <tf-text> elements with <w:r><w:t>

### DIFF
--- a/src/format-docx.cpp
+++ b/src/format-docx.cpp
@@ -389,6 +389,7 @@ std::string inject_docx(DOM& dom) {
 	// Remove the <tf-text> helper elements that we added
 	rx_replaceAll(R"X(<tf-text>([^<>]+)<w:r)X", "<w:r><w:t>$1</w:t></w:r>", udata, tmp);
 	rx_replaceAll(R"X(</w:r>([^<>]+)</tf-text>)X", "<w:r><w:t>$1</w:t></w:r>", udata, tmp);
+	rx_replaceAll(R"X(<tf-text>([^<>]+)</tf-text>)X", "<w:r><w:t>$1</w:t></w:r>", udata, tmp);
 	rx_replaceAll(R"X(</?tf-text/?>)X", "", udata, tmp);
 
 	// DOCX by default does ignores all leading/trailing whitespace, so tell it not do.


### PR DESCRIPTION
instead of just dropping them (for cases where they were not already surrounded by <w:r><w:t>)

fixes #28


I tried saving [input.docx](https://github.com/user-attachments/files/20055595/input.docx) as pdf from office 365 and then /usr/bin/diffpdf gave me
[diff.pdf](https://github.com/user-attachments/files/20055567/diff.pdf)
(it seems quite a lot of text was missing!)